### PR TITLE
feat: add Domain Claim API coverage to the resend skill

### DIFF
--- a/skill-evals/resend/evals.json
+++ b/skill-evals/resend/evals.json
@@ -414,6 +414,17 @@
         "Uses the last item's ID as the after parameter",
         "Limits to 100 per page"
       ]
+    },
+    {
+      "id": 38,
+      "prompt": "Another team already verified acme.com in their own Resend account, but it's our domain. How do we take it over so we can send from it?",
+      "expected_output": "Routes to domains.md 'Claim a Domain'. Explains resend.domains.claims.create then verify then get; that the domain transfers with NEW DKIM keys so DNS must be updated and the domain re-verified before sending; and that claims are Node SDK only (resend >= 6.14.0), no CLI yet.",
+      "files": [],
+      "expectations": [
+        "Identifies this as a domain claim (resend.domains.claims.create / verify / get)",
+        "Notes the transferred domain gets new DKIM keys — DNS must be updated and the domain verified before sending",
+        "Mentions it is Node SDK only and requires resend >= 6.14.0 (no CLI equivalent yet)"
+      ]
     }
   ]
 }

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -4,7 +4,7 @@ description: Use when working with the Resend email API — sending transactiona
 license: MIT
 metadata:
     author: resend
-    version: "3.3.3"
+    version: "3.4.0"
     homepage: https://resend.com/agent-skills
     source: https://github.com/resend/resend-skills
     openclaw:
@@ -160,7 +160,7 @@ export async function POST(req: Request) {
 | **Receive inbound emails** | [receiving.md](references/receiving.md) — domain setup, webhooks, attachments |
 | **Manage templates** (CRUD, variables) | [templates.md](references/templates.md) — lifecycle, aliases, pagination |
 | **Set up webhooks** (events, verification) | [webhooks.md](references/webhooks.md) — verification, CRUD, retry schedule, IP allowlist |
-| **Manage domains** (create, verify, DNS) | [domains.md](references/domains.md) — regions, TLS, tracking, capabilities |
+| **Manage domains** (create, verify, claim, DNS) | [domains.md](references/domains.md) — regions, TLS, tracking, claiming, capabilities |
 | **Manage contacts** (CRUD, properties) | [contacts.md](references/contacts.md) — segments, topics, custom properties |
 | **Send broadcasts** (marketing campaigns) | [broadcasts.md](references/broadcasts.md) — lifecycle, scheduling, template variables |
 | **Manage API keys** | [api-keys.md](references/api-keys.md) — permission scoping, domain restrictions |
@@ -179,7 +179,7 @@ Always install the latest SDK version. These are the minimum versions for full f
 
 | Language | Package | Min Version | Install |
 |----------|---------|-------------|---------|
-| Node.js | `resend` | >= 6.9.2 | `npm install resend` |
+| Node.js | `resend` | >= 6.14.0 | `npm install resend` |
 | Python | `resend` | >= 2.21.0 | `pip install resend` |
 | Go | `resend-go/v3` | >= 3.1.0 | `go get github.com/resend/resend-go/v3` |
 | Ruby | `resend` | >= 1.0.0 | `gem install resend` |
@@ -188,7 +188,7 @@ Always install the latest SDK version. These are the minimum versions for full f
 | Java | `resend-java` | >= 4.11.0 | See [installation.md](references/installation.md) |
 | .NET | `Resend` | >= 0.2.1 | `dotnet add package Resend` |
 
-> **If the project already has a Resend SDK installed**, check the version and upgrade if it's below the minimum. Older SDKs may be missing `webhooks.verify()` or `emails.receiving.get()`.
+> **If the project already has a Resend SDK installed**, check the version and upgrade if it's below the minimum. Older SDKs may be missing `webhooks.verify()`, `emails.receiving.get()`, or `domains.claims.*`.
 
 See [installation.md](references/installation.md) for full installation commands, language detection, and cURL fallback.
 

--- a/skills/resend/references/domains.md
+++ b/skills/resend/references/domains.md
@@ -25,6 +25,8 @@ Create → Add DNS records → Verify → Poll status → Send
 
 `resend.Domains.create/get/list/update/remove/verify` — same operations with snake_case params (e.g., `custom_return_path`, `open_tracking`, `click_tracking`).
 
+> **Claiming a domain another Resend account already verified?** See [Claim a Domain](#claim-a-domain) — Node SDK only, requires `resend >= 6.14.0`.
+
 ## Use a Subdomain
 
 Prefer a subdomain (e.g., `send.example.com`) over the root domain:
@@ -98,6 +100,50 @@ const { data, error } = await resend.domains.update({
 });
 ```
 
+## Claim a Domain
+
+Claiming takes over a domain **another Resend account has already verified**. The domain transfers to your account as a **brand-new domain with fresh DKIM keys**, so the previous account's DNS records can't be reused — you must update DNS and verify before sending or receiving.
+
+```
+Claim → Add TXT proof to DNS → Verify claim → (completed) → Update DKIM in DNS → Verify domain → Send
+```
+
+Claim methods are **Node SDK only** (`resend >= 6.14.0`) — no CLI or other-language SDK support yet.
+
+| Operation | Method | Notes |
+|-----------|--------|-------|
+| Start claim | `resend.domains.claims.create({ name })` | Same body as `domains.create`. Returns a `domain_claim` with `domain_id` + the TXT `record` to add |
+| Get claim | `resend.domains.claims.get(domainId)` | Latest claim for the placeholder domain — poll `status` |
+| Verify claim | `resend.domains.claims.verify(domainId)` | Triggers async DNS proof + transfer (not synchronous) |
+
+```typescript
+// 1. Start the claim — returns the placeholder domain id + TXT record to add
+const { data: claim, error } = await resend.domains.claims.create({
+  name: 'send.acme.com',
+});
+if (error) {
+  console.error(error);
+  return;
+}
+console.log(claim.domain_id); // placeholder domain id for later calls
+console.log(claim.record);    // { type: 'TXT', name, value, ttl } — add to DNS
+
+// 2. After adding the TXT record, trigger verification
+await resend.domains.claims.verify(claim.domain_id);
+
+// 3. Poll until the claim status is 'completed'
+const { data: latest } = await resend.domains.claims.get(claim.domain_id);
+console.log(latest.status); // 'pending' | 'verified' | 'completed' | 'blocked' | ...
+
+// 4. Once 'completed', the transferred domain has NEW DKIM records:
+//    fetch them, update your DNS, then verify the domain itself.
+const { data: domain } = await resend.domains.get(claim.domain_id);
+console.log(domain.records); // add these to DNS, then:
+await resend.domains.verify(claim.domain_id);
+```
+
+A `blocked` status means a safety check failed — inspect `blocked_reason` (`grace_period`, `recent_owner_activity`, `pending_scheduled_emails`).
+
 ## Parameter Reference
 
 | Parameter | Values | Default | Notes |
@@ -127,3 +173,7 @@ const { data, error } = await resend.domains.update({
 | Using `enforced` TLS with recipients that don't support it | Use `opportunistic` (default) unless you know all recipients support TLS |
 | Not checking `error` in Node.js | SDK returns `{ data, error }`, does not throw — always destructure and check |
 | Forgetting region on create | Defaults to `us-east-1` — set explicitly for EU/SA/AP data residency requirements |
+| Reusing the old account's DNS records after a claim | A claim issues **new DKIM keys** — fetch the transferred domain with `domains.get()`, update DNS, then `domains.verify()` |
+| Treating the claim as done at `completed` | `completed` only means the transfer finished — the domain still needs its new DKIM records in DNS and a `domains.verify()` to send |
+| Expecting `claims.verify()` to be synchronous | It triggers an async DNS proof + transfer — poll `claims.get()` for `status` |
+| Looking for a `claim` CLI command or Python method | Claims are **Node SDK only** (`resend >= 6.14.0`) today |

--- a/skills/resend/references/installation.md
+++ b/skills/resend/references/installation.md
@@ -1,6 +1,6 @@
 # Resend SDK Installation Guide
 
-Always install the latest SDK version to ensure you have support for all features including webhook verification (`webhooks.verify()`) and email receiving (`emails.receiving.get()`). Older versions may not include these methods.
+Always install the latest SDK version to ensure you have support for all features including webhook verification (`webhooks.verify()`), email receiving (`emails.receiving.get()`), and domain claiming (`domains.claims.*`). Older versions may not include these methods.
 
 ## Minimum SDK Versions
 
@@ -8,7 +8,7 @@ These are the minimum versions required for full functionality (sending, receivi
 
 | Language | Package | Min Version | Install |
 |----------|---------|-------------|---------|
-| Node.js | `resend` | >= 6.9.2 | `npm install resend` |
+| Node.js | `resend` | >= 6.14.0 | `npm install resend` |
 | Python | `resend` | >= 2.21.0 | `pip install resend` |
 | Go | `resend-go/v3` | >= 3.1.0 | `go get github.com/resend/resend-go/v3` |
 | Ruby | `resend` | >= 1.0.0 | `gem install resend` |
@@ -17,7 +17,7 @@ These are the minimum versions required for full functionality (sending, receivi
 | Java | `resend-java` | >= 4.11.0 | See [Maven/Gradle](#java) below |
 | .NET | `Resend` | >= 0.2.1 | `dotnet add package Resend` |
 
-> **If the project already has a Resend SDK installed**, check the version and upgrade if it's below the minimum. Older SDKs may be missing `webhooks.verify()` or `emails.receiving.get()`, which are required for inbound email and webhook security.
+> **If the project already has a Resend SDK installed**, check the version and upgrade if it's below the minimum. Older SDKs may be missing `webhooks.verify()`, `emails.receiving.get()`, or `domains.claims.*`, which power webhook security, inbound email, and domain claiming.
 
 ## Detecting Project Language
 


### PR DESCRIPTION
Teaches the `resend` skill the **Domain Claim API** (`resend.domains.claims.create/get/verify`, shipping in `resend@6.14.0`).

**Changes (all in authored skills + evals):**
- `skills/resend/references/domains.md` — new **Claim a Domain** section (lifecycle: claim → add TXT → verify claim → completed → update DKIM → verify domain), Node SDK example, method table, + Common Mistakes rows. Plus a discovery pointer.
- `skills/resend/SKILL.md` — routing row now lists "claim"; Node min version `>= 6.9.2` → `>= 6.14.0`; prose note + `metadata.version` 3.3.3 → 3.4.0.
- `skills/resend/references/installation.md` — Node min version + prose.
- `skill-evals/resend/evals.json` — new routing eval (id 38) for the claim flow.

**Node-only by design:** claims exist only in the Node SDK today; the section explicitly says no CLI/Python/other-SDK support yet. Synced skills (`resend-cli`, etc.) untouched per AGENTS.md.

Related: docs resend-docs#1570/#1575/#1576, SDK resend-node#985/#987.

⚠️ **Merge gate:** hold until `resend@6.14.0` is GA on npm (production release in flight) — the version tables reference the stable release.