### PR TITLE
fix(resend): update claim coverage to reflect CLI support

### DIFF
--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -4,7 +4,7 @@ description: Use when working with the Resend email API — sending transactiona
 license: MIT
 metadata:
     author: resend
-    version: "3.4.0"
+    version: "3.4.1"
     homepage: https://resend.com/agent-skills
     source: https://github.com/resend/resend-skills
     openclaw:

--- a/skills/resend/references/domains.md
+++ b/skills/resend/references/domains.md
@@ -25,7 +25,7 @@ Create → Add DNS records → Verify → Poll status → Send
 
 `resend.Domains.create/get/list/update/remove/verify` — same operations with snake_case params (e.g., `custom_return_path`, `open_tracking`, `click_tracking`).
 
-> **Claiming a domain another Resend account already verified?** See [Claim a Domain](#claim-a-domain) — Node SDK only, requires `resend >= 6.14.0`.
+> **Claiming a domain another Resend account already verified?** See [Claim a Domain](#claim-a-domain) — Node SDK (`resend >= 6.14.0`) and CLI (`resend domains claim`).
 
 ## Use a Subdomain
 
@@ -108,7 +108,7 @@ Claiming takes over a domain **another Resend account has already verified**. Th
 Claim → Add TXT proof to DNS → Verify claim → (completed) → Update DKIM in DNS → Verify domain → Send
 ```
 
-Claim methods are **Node SDK only** (`resend >= 6.14.0`) — no CLI or other-language SDK support yet.
+Claim methods are available via the **Node SDK** (`resend >= 6.14.0`) and the **CLI** (`resend domains claim`) — no other-language SDK support yet.
 
 | Operation | Method | Notes |
 |-----------|--------|-------|
@@ -176,4 +176,4 @@ A `blocked` status means a safety check failed — inspect `blocked_reason` (`gr
 | Reusing the old account's DNS records after a claim | A claim issues **new DKIM keys** — fetch the transferred domain with `domains.get()`, update DNS, then `domains.verify()` |
 | Treating the claim as done at `completed` | `completed` only means the transfer finished — the domain still needs its new DKIM records in DNS and a `domains.verify()` to send |
 | Expecting `claims.verify()` to be synchronous | It triggers an async DNS proof + transfer — poll `claims.get()` for `status` |
-| Looking for a `claim` CLI command or Python method | Claims are **Node SDK only** (`resend >= 6.14.0`) today |
+| Looking for a claim method in Python or another language | Claims are Node SDK + CLI only today — no other-language SDK support yet |


### PR DESCRIPTION
Follow-up to #77. The `resend-cli` PR (resend/resend-cli#325) adds `resend domains claim create|get|verify`, so the three "Node SDK only" caveats in `skills/resend/references/domains.md` are now outdated.

**Changes (3 lines in `domains.md` + version bump):**
- Discovery pointer (top): adds `and CLI (`resend domains claim`)`.
- Section intro: `Node SDK only … no CLI` → `Node SDK and CLI … no other-language SDK`.
- Common Mistakes row: was "Looking for a CLI command or Python method" → now "Python or another language" (the CLI caveat is gone; Python/Go/etc. caveat remains accurate).
- `metadata.version` 3.4.0 → 3.4.1 (patch — content correction).