### PR TITLE
fix: align domain claim docs and eval with the 6-field API contract

### DIFF
--- a/skill-evals/resend/evals.json
+++ b/skill-evals/resend/evals.json
@@ -418,12 +418,12 @@
     {
       "id": 38,
       "prompt": "Another team already verified acme.com in their own Resend account, but it's our domain. How do we take it over so we can send from it?",
-      "expected_output": "Routes to domains.md 'Claim a Domain'. Explains resend.domains.claims.create then verify then get; that the domain transfers with NEW DKIM keys so DNS must be updated and the domain re-verified before sending; and that claims are Node SDK only (resend >= 6.14.0), no CLI yet.",
+      "expected_output": "Routes to domains.md 'Claim a Domain'. Explains resend.domains.claims.create then verify then get; that the domain transfers with NEW DKIM keys so DNS must be updated and the domain re-verified before sending; and that claims are available via the Node SDK (resend >= 6.14.0) and the CLI (`resend domains claim`).",
       "files": [],
       "expectations": [
         "Identifies this as a domain claim (resend.domains.claims.create / verify / get)",
         "Notes the transferred domain gets new DKIM keys — DNS must be updated and the domain verified before sending",
-        "Mentions it is Node SDK only and requires resend >= 6.14.0 (no CLI equivalent yet)"
+        "Mentions it is available via the Node SDK (resend >= 6.14.0) and the CLI (`resend domains claim`)"
       ]
     }
   ]

--- a/skills/resend-cli/SKILL.md
+++ b/skills/resend-cli/SKILL.md
@@ -11,7 +11,7 @@ description: >
 license: MIT
 metadata:
   author: resend
-  version: "2.2.0"
+  version: "2.3.0"
   homepage: https://resend.com/docs/cli-agents
   source: https://github.com/resend/resend-cli
   openclaw:

--- a/skills/resend-cli/references/domains.md
+++ b/skills/resend-cli/references/domains.md
@@ -102,6 +102,9 @@ Claim status values: `pending` | `verified` | `completed` | `blocked` | `expired
 | `--name <domain>` | string | Yes (non-interactive) | Domain name to claim (e.g., `example.com`) |
 | `--region <region>` | string | No | `us-east-1` \| `eu-west-1` \| `sa-east-1` \| `ap-northeast-1` |
 | `--tracking-subdomain <subdomain>` | string | No | Subdomain for click and open tracking (e.g., `track`) |
+| `--custom-return-path <subdomain>` | string | No | Subdomain for the Return-Path address (e.g., `bounce`) |
+| `--open-tracking` / `--no-open-tracking` | boolean | No | Enable/disable open tracking |
+| `--click-tracking` / `--no-click-tracking` | boolean | No | Enable/disable click tracking |
 
 **Output:** `domain_claim` object with `domain_id` (the placeholder domain) and a TXT `record` to add to DNS.
 

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -4,7 +4,7 @@ description: Use when working with the Resend email API — sending transactiona
 license: MIT
 metadata:
     author: resend
-    version: "3.4.1"
+    version: "3.4.2"
     homepage: https://resend.com/agent-skills
     source: https://github.com/resend/resend-skills
     openclaw:

--- a/skills/resend/references/domains.md
+++ b/skills/resend/references/domains.md
@@ -112,7 +112,7 @@ Claim methods are available via the **Node SDK** (`resend >= 6.14.0`) and the **
 
 | Operation | Method | Notes |
 |-----------|--------|-------|
-| Start claim | `resend.domains.claims.create({ name })` | Same body as `domains.create`. Returns a `domain_claim` with `domain_id` + the TXT `record` to add |
+| Start claim | `resend.domains.claims.create({ name })` | Accepts `name` (required) + optional `region`, `customReturnPath`, `openTracking`, `clickTracking`, `trackingSubdomain` (`domains.create` body minus `tls`/`capabilities`). Returns a `domain_claim` with `domain_id` + the TXT `record` to add |
 | Get claim | `resend.domains.claims.get(domainId)` | Latest claim for the placeholder domain — poll `status` |
 | Verify claim | `resend.domains.claims.verify(domainId)` | Triggers async DNS proof + transfer (not synchronous) |
 


### PR DESCRIPTION
## Summary

Four corrections to bring the `resend` skill and vendored CLI skill in sync with the real API contract.

**`skills/resend/references/domains.md`:** The "Start claim" row said "Same body as `domains.create`" — overstated. Replaced with the accurate 6-field list (`name`, `region`, `customReturnPath`, `openTracking`, `clickTracking`, `trackingSubdomain`) and a note that `tls`/`capabilities` are excluded.

**`skill-evals/resend/evals.json` (eval #38):** `expected_output` and `expectations[2]` still said "Node SDK only, no CLI yet" — stale since the CLI shipped in `resend-cli@2.4.0`. Updated to reflect both Node SDK and CLI support.

**`skills/resend/SKILL.md`:** version 3.4.1 → 3.4.2.

**`skills/resend-cli/` (vendored copy):** Synced the 3 new `domains claim create` flags (`--custom-return-path`, `--open-tracking`, `--click-tracking`) matching the CLI repo PR; version 2.2.0 → 2.3.0.