### PR TITLE
Point MCP server at hosted remote (mcp.resend.com)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
     "resend": {
-      "command": "npx",
-      "args": ["-y", "resend-mcp"],
-      "env": {
-        "RESEND_API_KEY": "${RESEND_API_KEY}"
+      "type": "http",
+      "url": "https://mcp.resend.com",
+      "headers": {
+        "Authorization": "Bearer ${RESEND_API_KEY}"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Then select the ones you wish to install.
 
 ## MCP Server
 
-The plugin includes the [Resend MCP server](https://github.com/resend/resend-mcp), giving agents tool access to the full Resend API.
+The plugin registers Resend's hosted [MCP server](https://github.com/resend/resend-mcp) at `https://mcp.resend.com` (streamable HTTP), giving agents tool access to the full Resend API. It authenticates with your `RESEND_API_KEY` via a bearer header — set that env var where your agent runs. Get a key at [resend.com/api-keys](https://resend.com/api-keys).
 
 ## Plugins
 

--- a/mcp.json
+++ b/mcp.json
@@ -1,10 +1,10 @@
 {
   "mcpServers": {
     "resend": {
-      "command": "npx",
-      "args": ["-y", "resend-mcp"],
-      "env": {
-        "RESEND_API_KEY": "${RESEND_API_KEY}"
+      "type": "http",
+      "url": "https://mcp.resend.com",
+      "headers": {
+        "Authorization": "Bearer ${RESEND_API_KEY}"
       }
     }
   }


### PR DESCRIPTION
## What

Switch the bundled MCP server from the local stdio server (`npx resend-mcp`) to Resend's **hosted remote** MCP at `https://mcp.resend.com` (streamable HTTP), in both `.mcp.json` and the duplicate root `mcp.json`.

```json
{
  "mcpServers": {
    "resend": {
      "type": "http",
      "url": "https://mcp.resend.com",
      "headers": { "Authorization": "Bearer ${RESEND_API_KEY}" }
    }
  }
}
```

Auth is unchanged — same `RESEND_API_KEY`, now passed as a bearer header instead of an env var to a local process. **Only the transport moves** (local → remote); no new credential, no OAuth flow.

Applies across all four platforms: Claude Code (auto-discovers `.mcp.json`), OpenAI Codex (`.codex-plugin/plugin.json` references `./.mcp.json`), Cursor, and Grok.

README "MCP Server" section updated to describe the hosted endpoint + `RESEND_API_KEY`.

## Follow-ups (not in this PR)

- After merge, bump the pinned `sha` in [xai-org/plugin-marketplace#32](https://github.com/xai-org/plugin-marketplace/pull/32) to this commit — that clears the temporary `stdio` regression in the Grok catalog (it'll read `http` again).
- Switching the server default to **OAuth** (dropping the bearer header, documenting API-key as an opt-in override) is a separate later PR.