### PR TITLE
Point Cursor plugin at the MCP file

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -3,6 +3,8 @@
   "displayName": "Resend",
   "description": "Skills and MCP server for the Resend email platform — sending, receiving, templates, CLI, React Email, and deliverability best practices.",
   "version": "1.0.0",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
   "author": {
     "name": "Resend",
     "url": "https://resend.com"


### PR DESCRIPTION
## What

Adds the `mcpServers` pointer (and `skills`) to `.cursor-plugin/plugin.json` so the Cursor plugin registers the hosted Resend MCP server.

```json
"skills": "./skills/",
"mcpServers": "./.mcp.json",
```

## Why

The Cursor manifest was the only platform plugin not wired to `./.mcp.json` — the Codex manifest (`.codex-plugin/plugin.json`) already points to it. Without this, Cursor wouldn't load the Resend MCP server (`https://mcp.resend.com`) or the skills.

## Notes

Base is `mcp-remote-endpoint` since this builds on that branch's hosted-endpoint work.