### PR TITLE
Bump plugin version to 1.0.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "resend",
   "description": "Send and receive emails, build with React Email, follow deliverability best practices",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Resend",
     "email": "support@resend.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "resend",
   "displayName": "Resend",
   "description": "Skills and MCP server for the Resend email platform — sending, receiving, templates, CLI, React Email, and deliverability best practices.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "author": {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "resend",
   "displayName": "Resend",
   "description": "Skills and MCP server for the Resend email platform — sending, receiving, templates, CLI, React Email, and deliverability best practices.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Resend",
     "url": "https://resend.com"

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Resend skills for Grok — send, receive, and manage email: transactional and batch sending, inbound email agents, React Email templates, the Resend CLI, and deliverability best practices.",
   "author": {
     "name": "Resend",


### PR DESCRIPTION
## What

Bumps the plugin manifest `version` from `1.0.0` → `1.0.1` across all four platform manifests:

- `.claude-plugin/plugin.json`
- `.cursor-plugin/plugin.json`
- `.codex-plugin/plugin.json`
- `.grok-plugin/plugin.json`

No functional code changes — this is a release-versioning change only.

## Why

Recent merges (e.g. #85, *"Point MCP server at hosted remote (mcp.resend.com)"*) changed plugin behavior but are still tagged `1.0.0`. **Already-installed users will not receive those changes until the `version` field is bumped** — pushing to `main` alone does nothing.

This is by design. Claude Code uses the manifest `version` as the **cache key** for updates:

> Claude Code uses the plugin's version as the cache key that determines whether an update is available. When you run `/plugin update` or auto-update fires, Claude Code computes the current version and skips the update if it matches what's already installed.
>
> — [Plugins reference → Version management](https://code.claude.com/docs/en/plugins-reference#version-management)

Because we set an explicit `version` in `plugin.json`, we are on the **explicit-version** track, which requires a manual bump for every release:

> **Explicit version** — Set `"version": "2.1.0"` in `plugin.json`. Users get updates only when you bump this field. **Pushing new commits without bumping it has no effect**, and `/plugin update` reports "already at the latest version."
>
> ⚠️ If you set `version` in `plugin.json`, you must bump it every time you want users to receive changes. Pushing new commits alone is not enough, because Claude Code sees the same version string and keeps the cached copy.
>
> — [Plugins reference → Version management](https://code.claude.com/docs/en/plugins-reference#version-management)

The version is resolved from the first of these that is set ([same section](https://code.claude.com/docs/en/plugins-reference#version-management)):

1. `version` in `plugin.json` ← **we use this**
2. `version` in the marketplace entry
3. the git commit SHA of the source
4. `unknown`

Since #1 is set, the commit SHA is irrelevant for update detection — only a bump of this field triggers delivery.

## How updates reach users after this merges

For users who installed from the official Anthropic marketplace ([claude.com/plugins](https://claude.com/plugins)), delivery is automatic:

> Claude Code can automatically update marketplaces and their installed plugins at startup. When auto-update is enabled for a marketplace, Claude Code refreshes the marketplace data and updates installed plugins to their latest versions. If any plugins were updated, you'll see a notification prompting you to run `/reload-plugins`.
>
> **Official Anthropic marketplaces have auto-update enabled by default.** Third-party and local development marketplaces have auto-update disabled by default.
>
> — [Discover plugins → Configure auto-updates](https://code.claude.com/docs/en/discover-plugins#configure-auto-updates)

So once merged and bumped:

1. The marketplace catalog re-pins to the new commit. For the community marketplace this is automated — *"CI bumps the pin automatically as you push new commits to your repository... The public catalog syncs nightly"* ([Submit your plugin](https://code.claude.com/docs/en/plugins#submit-your-plugin-to-the-community-marketplace)).
2. On next startup, auto-update-enabled clients pull `1.0.1` (because the version string changed).
3. Users are notified to run `/reload-plugins`.

No per-release contact with the Anthropic team is required — only the initial listing is curated. Users who disabled auto-update (or set `DISABLE_AUTOUPDATER`) pick it up manually via `/plugin update`.

## Versioning note

`1.0.0` → `1.0.1` (PATCH) per [semver](https://semver.org), matching the docs' guidance to *"bump MAJOR for breaking changes, MINOR for new features, PATCH for bug fixes."* If we consider the hosted-MCP-endpoint change a feature rather than a fix, this could instead be `1.1.0` — easy to adjust.
