### PR TITLE
chore: point MCP server URL at mcp.resend.com/mcp

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "resend",
   "description": "Send and receive emails, build with React Email, follow deliverability best practices",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "Resend",
     "email": "support@resend.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "resend",
   "displayName": "Resend",
   "description": "Skills and MCP server for the Resend email platform — sending, receiving, templates, CLI, React Email, and deliverability best practices.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "author": {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "resend",
   "displayName": "Resend",
   "description": "Skills and MCP server for the Resend email platform — sending, receiving, templates, CLI, React Email, and deliverability best practices.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "Resend",
     "url": "https://resend.com"

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Resend skills for Grok — send, receive, and manage email: transactional and batch sending, inbound email agents, React Email templates, the Resend CLI, and deliverability best practices.",
   "author": {
     "name": "Resend",

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "resend": {
       "type": "http",
-      "url": "https://mcp.resend.com",
+      "url": "https://mcp.resend.com/mcp",
       "headers": {
         "Authorization": "Bearer ${RESEND_API_KEY}"
       }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Then select the ones you wish to install.
 
 ## MCP Server
 
-The plugin registers Resend's hosted [MCP server](https://github.com/resend/resend-mcp) at `https://mcp.resend.com` (streamable HTTP), giving agents tool access to the full Resend API. It authenticates with your `RESEND_API_KEY` via a bearer header — set that env var where your agent runs. Get a key at [resend.com/api-keys](https://resend.com/api-keys).
+The plugin registers Resend's hosted [MCP server](https://github.com/resend/resend-mcp) at `https://mcp.resend.com/mcp` (streamable HTTP), giving agents tool access to the full Resend API. It authenticates with your `RESEND_API_KEY` via a bearer header — set that env var where your agent runs. Get a key at [resend.com/api-keys](https://resend.com/api-keys).
 
 ## Plugins
 

--- a/mcp.json
+++ b/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "resend": {
       "type": "http",
-      "url": "https://mcp.resend.com",
+      "url": "https://mcp.resend.com/mcp",
       "headers": {
         "Authorization": "Bearer ${RESEND_API_KEY}"
       }


### PR DESCRIPTION
## What

Update the plugin's hosted MCP **connection URL** to the explicit `/mcp` path (`https://mcp.resend.com` → `https://mcp.resend.com/mcp`).

## Files
- `.mcp.json` — `mcpServers.resend.url`
- `mcp.json` — `mcpServers.resend.url`
- `README.md` — the "MCP Server" section reference

## Notes
The Claude, Cursor, Codex, and Grok plugin manifests (`.claude-plugin/`, `.cursor-plugin/`, `.codex-plugin/`, `.grok-plugin/`) don't hardcode the URL — they inherit it from these root configs (Codex references `./.mcp.json` directly; the others read `.mcp.json` by convention). So this single change covers all four clients; no per-client edits needed.

The server already POST-handles both `/` and `/mcp`; OAuth identity (`resource`, discovery) stays at the origin.