### PR TITLE
Use OAuth for hosted MCP server, drop API key header

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "resend",
   "description": "Send and receive emails, build with React Email, follow deliverability best practices",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "Resend",
     "email": "support@resend.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "resend",
   "displayName": "Resend",
   "description": "Skills and MCP server for the Resend email platform — sending, receiving, templates, CLI, React Email, and deliverability best practices.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "author": {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "resend",
   "displayName": "Resend",
   "description": "Skills and MCP server for the Resend email platform — sending, receiving, templates, CLI, React Email, and deliverability best practices.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": {
     "name": "Resend",
     "url": "https://resend.com"

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "resend",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Resend skills for Grok — send, receive, and manage email: transactional and batch sending, inbound email agents, React Email templates, the Resend CLI, and deliverability best practices.",
   "author": {
     "name": "Resend",

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "resend": {
       "type": "http",
-      "url": "https://mcp.resend.com/mcp",
-      "headers": {
-        "Authorization": "Bearer ${RESEND_API_KEY}"
-      }
+      "url": "https://mcp.resend.com/mcp"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Then select the ones you wish to install.
 
 ## MCP Server
 
-The plugin registers Resend's hosted [MCP server](https://github.com/resend/resend-mcp) at `https://mcp.resend.com/mcp` (streamable HTTP), giving agents tool access to the full Resend API. It authenticates with your `RESEND_API_KEY` via a bearer header — set that env var where your agent runs. Get a key at [resend.com/api-keys](https://resend.com/api-keys).
+The plugin registers Resend's hosted [MCP server](https://github.com/resend/resend-mcp) at `https://mcp.resend.com/mcp` (streamable HTTP), giving agents tool access to the full Resend API. It authenticates via OAuth — your client walks you through sign-in on first connect, so no API key or header configuration is needed.
 
 ## Plugins
 

--- a/mcp.json
+++ b/mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "resend": {
       "type": "http",
-      "url": "https://mcp.resend.com/mcp",
-      "headers": {
-        "Authorization": "Bearer ${RESEND_API_KEY}"
-      }
+      "url": "https://mcp.resend.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## What

The hosted MCP server at `mcp.resend.com` now authenticates via **OAuth**, so the `Authorization: Bearer ${RESEND_API_KEY}` header is no longer needed.

## Changes

- **`.mcp.json` / `mcp.json`** — removed the `headers` block; the server connects over OAuth via the URL alone.
- **`README.md`** — rewrote the MCP Server section to describe OAuth sign-in on first connect instead of the bearer-header setup.
- **Plugin manifests** — bumped `1.0.2` → `1.0.3` across Claude, Cursor, Codex, and Grok manifests.

## Notes

- Skills were checked but need no changes — no skill contains MCP server config. Remaining `RESEND_API_KEY` references in skills are all SDK/CLI usage, which still require an API key.