### PR TITLE
chore: document bounce details in email retrieval responses

### DIFF
--- a/skills/resend-cli/references/emails.md
+++ b/skills/resend-cli/references/emails.md
@@ -54,6 +54,17 @@ Retrieve a sent email by ID.
 }
 ```
 
+When `last_event` is `bounced`, the output also includes a `bounce` object (omitted otherwise):
+
+```json
+"bounce": {
+  "message": "The recipient's email provider sent a hard bounce message.",
+  "type": "Permanent",
+  "subType": "General",
+  "diagnosticCode": ["smtp; 550 5.1.1 user unknown"]
+}
+```
+
 ---
 
 ## emails list

--- a/skills/resend-cli/references/emails.md
+++ b/skills/resend-cli/references/emails.md
@@ -54,17 +54,6 @@ Retrieve a sent email by ID.
 }
 ```
 
-When `last_event` is `bounced`, the output also includes a `bounce` object (omitted otherwise):
-
-```json
-"bounce": {
-  "message": "The recipient's email provider sent a hard bounce message.",
-  "type": "Permanent",
-  "subType": "General",
-  "diagnosticCode": ["smtp; 550 5.1.1 user unknown"]
-}
-```
-
 ---
 
 ## emails list

--- a/skills/resend/references/sending/email-management.md
+++ b/skills/resend/references/sending/email-management.md
@@ -44,6 +44,26 @@ email = resend.Emails.get("email_abc123")
 print(email["status"])
 ```
 
+### Bounce Details
+
+When `last_event` is `bounced`, the response includes a `bounce` object with details from the receiving server. It is omitted for all other statuses, and is not included in the list endpoint.
+
+```json
+"bounce": {
+  "message": "The recipient's email provider sent a hard bounce message.",
+  "type": "Permanent",
+  "subType": "General",
+  "diagnosticCode": ["smtp; 550 5.1.1 user unknown"]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message` | string \| null | Detailed bounce message from the receiving server |
+| `type` | string \| null | `Permanent`, `Transient`, or `Undetermined` |
+| `subType` | string \| null | e.g. `General`, `NoEmail`, `MailboxFull` — see [webhooks.md](../webhooks.md#bounce-types) for the full list |
+| `diagnosticCode` | string[] | SMTP diagnostic responses, including status code and reason |
+
 ### Reschedule a Scheduled Email
 
 ```typescript


### PR DESCRIPTION
## Summary

- Documents the `bounce` object returned by `GET /emails/:id` when `last_event` is `bounced`, added in resend/resend-monorepo#5950.
- `skills/resend/references/sending/email-management.md`: new "Bounce Details" section with an example payload and field table (`message`, `type`, `subType`, `diagnosticCode`), noting the field is omitted for other statuses and not included in the list endpoint.

## Test plan

- [ ] Confirm the field names and example values match the `GET /emails/:id` response shape from the monorepo PR.