### PR TITLE
feat: domain claims now in Python, Ruby, Go, Rust, and Java SDKs

### DIFF
--- a/skill-evals/resend/evals.json
+++ b/skill-evals/resend/evals.json
@@ -418,12 +418,12 @@
     {
       "id": 38,
       "prompt": "Another team already verified acme.com in their own Resend account, but it's our domain. How do we take it over so we can send from it?",
-      "expected_output": "Routes to domains.md 'Claim a Domain'. Explains resend.domains.claims.create then verify then get; that the domain transfers with NEW DKIM keys so DNS must be updated and the domain re-verified before sending; and that claims are available via the Node SDK (resend >= 6.14.0) and the CLI (`resend domains claim`).",
+      "expected_output": "Routes to domains.md 'Claim a Domain'. Explains resend.domains.claims.create then verify then get; that the domain transfers with NEW DKIM keys so DNS must be updated and the domain re-verified before sending; and that claims are available in the Node.js, Python, Ruby, Go, Rust, and Java SDKs, and the CLI (`resend domains claim`).",
       "files": [],
       "expectations": [
         "Identifies this as a domain claim (resend.domains.claims.create / verify / get)",
         "Notes the transferred domain gets new DKIM keys — DNS must be updated and the domain verified before sending",
-        "Mentions it is available via the Node SDK (resend >= 6.14.0) and the CLI (`resend domains claim`)"
+        "Mentions availability in the Node.js, Python, Ruby, Go, Rust, and Java SDKs, and the CLI (`resend domains claim`)"
       ]
     }
   ]

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -180,12 +180,12 @@ Always install the latest SDK version. These are the minimum versions for full f
 | Language | Package | Min Version | Install |
 |----------|---------|-------------|---------|
 | Node.js | `resend` | >= 6.14.0 | `npm install resend` |
-| Python | `resend` | >= 2.21.0 | `pip install resend` |
-| Go | `resend-go/v3` | >= 3.1.0 | `go get github.com/resend/resend-go/v3` |
-| Ruby | `resend` | >= 1.0.0 | `gem install resend` |
+| Python | `resend` | >= 2.34.0 | `pip install resend` |
+| Go | `resend-go/v3` | >= 3.11.0 | `go get github.com/resend/resend-go/v3` |
+| Ruby | `resend` | >= 1.6.0 | `gem install resend` |
 | PHP | `resend/resend-php` | >= 1.1.0 | `composer require resend/resend-php` |
-| Rust | `resend-rs` | >= 0.20.0 | `cargo add resend-rs` |
-| Java | `resend-java` | >= 4.11.0 | See [installation.md](references/installation.md) |
+| Rust | `resend-rs` | >= 0.26.1 | `cargo add resend-rs` |
+| Java | `resend-java` | >= 4.16.0 | See [installation.md](references/installation.md) |
 | .NET | `Resend` | >= 0.2.1 | `dotnet add package Resend` |
 
 > **If the project already has a Resend SDK installed**, check the version and upgrade if it's below the minimum. Older SDKs may be missing `webhooks.verify()`, `emails.receiving.get()`, or `domains.claims.*`.

--- a/skills/resend/references/domains.md
+++ b/skills/resend/references/domains.md
@@ -25,7 +25,7 @@ Create → Add DNS records → Verify → Poll status → Send
 
 `resend.Domains.create/get/list/update/remove/verify` — same operations with snake_case params (e.g., `custom_return_path`, `open_tracking`, `click_tracking`).
 
-> **Claiming a domain another Resend account already verified?** See [Claim a Domain](#claim-a-domain) — Node SDK (`resend >= 6.14.0`) and CLI (`resend domains claim`).
+> **Claiming a domain another Resend account already verified?** See [Claim a Domain](#claim-a-domain) — available in the Node.js, Python, Ruby, Go, Rust, and Java SDKs, and the CLI (`resend domains claim`).
 
 ## Use a Subdomain
 
@@ -108,13 +108,15 @@ Claiming takes over a domain **another Resend account has already verified**. Th
 Claim → Add TXT proof to DNS → Verify claim → (completed) → Update DKIM in DNS → Verify domain → Send
 ```
 
-Claim methods are available via the **Node SDK** (`resend >= 6.14.0`) and the **CLI** (`resend domains claim`) — no other-language SDK support yet.
+Claim methods are available in the **Node.js** (`resend >= 6.14.0`), **Python** (`resend >= 2.34.0`), **Ruby** (`resend >= 1.6.0`), **Go** (`resend-go/v3 >= 3.11.0`), **Rust** (`resend-rs >= 0.26.1`), and **Java** (`resend-java >= 4.16.0`) SDKs, plus the **CLI** (`resend domains claim`) and REST API. Not yet in the PHP or .NET SDKs.
 
 | Operation | Method | Notes |
 |-----------|--------|-------|
 | Start claim | `resend.domains.claims.create({ name })` | Accepts `name` (required) + optional `region`, `customReturnPath`, `openTracking`, `clickTracking`, `trackingSubdomain` (`domains.create` body minus `tls`/`capabilities`). Returns a `domain_claim` with `domain_id` + the TXT `record` to add |
 | Get claim | `resend.domains.claims.get(domainId)` | Latest claim for the placeholder domain — poll `status` |
 | Verify claim | `resend.domains.claims.verify(domainId)` | Triggers async DNS proof + transfer (not synchronous) |
+
+Method naming per SDK: Python `resend.Domains.Claims.create/get/verify` (async: `create_async/get_async/verify_async`), Ruby `Resend::Domains::Claims.create/get/verify`, Go `client.DomainClaims.Create(&CreateDomainClaimRequest{...})/Get(domainId)/Verify(domainId)` (+ `*WithContext`), Rust `domains.claim(opts)/get_claim(id)/verify_claim(id)`, Java `resend.domains().claims().create(ClaimDomainOptions)/get(id)/verify(id)`.
 
 ```typescript
 // 1. Start the claim — returns the placeholder domain id + TXT record to add
@@ -140,6 +142,26 @@ console.log(latest.status); // 'pending' | 'verified' | 'completed' | 'blocked' 
 const { data: domain } = await resend.domains.get(claim.domain_id);
 console.log(domain.records); // add these to DNS, then:
 await resend.domains.verify(claim.domain_id);
+```
+
+```python
+# 1. Start the claim — returns the placeholder domain id + TXT record to add
+claim = resend.Domains.Claims.create({"name": "send.acme.com"})
+print(claim["domain_id"])  # placeholder domain id for later calls
+print(claim["record"])     # {type: 'TXT', name, value, ttl} — add to DNS
+
+# 2. After adding the TXT record, trigger verification
+resend.Domains.Claims.verify(domain_id=claim["domain_id"])
+
+# 3. Poll until the claim status is 'completed'
+latest = resend.Domains.Claims.get(domain_id=claim["domain_id"])
+print(latest["status"])  # 'pending' | 'verified' | 'completed' | 'blocked' | ...
+
+# 4. Once 'completed', fetch the transferred domain's NEW DKIM records,
+#    update DNS, then verify the domain itself.
+domain = resend.Domains.get(claim["domain_id"])
+print(domain["records"])  # add these to DNS, then:
+resend.Domains.verify(claim["domain_id"])
 ```
 
 A `blocked` status means a safety check failed — inspect `blocked_reason` (`grace_period`, `recent_owner_activity`, `pending_scheduled_emails`).
@@ -176,4 +198,4 @@ A `blocked` status means a safety check failed — inspect `blocked_reason` (`gr
 | Reusing the old account's DNS records after a claim | A claim issues **new DKIM keys** — fetch the transferred domain with `domains.get()`, update DNS, then `domains.verify()` |
 | Treating the claim as done at `completed` | `completed` only means the transfer finished — the domain still needs its new DKIM records in DNS and a `domains.verify()` to send |
 | Expecting `claims.verify()` to be synchronous | It triggers an async DNS proof + transfer — poll `claims.get()` for `status` |
-| Looking for a claim method in Python or another language | Claims are Node SDK + CLI only today — no other-language SDK support yet |
+| Looking for a claim method in PHP or .NET | Claims are in the Node.js, Python, Ruby, Go, Rust, and Java SDKs (plus CLI and REST API) — PHP/.NET don't support them yet |

--- a/skills/resend/references/installation.md
+++ b/skills/resend/references/installation.md
@@ -9,12 +9,12 @@ These are the minimum versions required for full functionality (sending, receivi
 | Language | Package | Min Version | Install |
 |----------|---------|-------------|---------|
 | Node.js | `resend` | >= 6.14.0 | `npm install resend` |
-| Python | `resend` | >= 2.21.0 | `pip install resend` |
-| Go | `resend-go/v3` | >= 3.1.0 | `go get github.com/resend/resend-go/v3` |
-| Ruby | `resend` | >= 1.0.0 | `gem install resend` |
+| Python | `resend` | >= 2.34.0 | `pip install resend` |
+| Go | `resend-go/v3` | >= 3.11.0 | `go get github.com/resend/resend-go/v3` |
+| Ruby | `resend` | >= 1.6.0 | `gem install resend` |
 | PHP | `resend/resend-php` | >= 1.1.0 | `composer require resend/resend-php` |
-| Rust | `resend-rs` | >= 0.20.0 | `cargo add resend-rs` |
-| Java | `resend-java` | >= 4.11.0 | See [Maven/Gradle](#java) below |
+| Rust | `resend-rs` | >= 0.26.1 | `cargo add resend-rs` |
+| Java | `resend-java` | >= 4.16.0 | See [Maven/Gradle](#java) below |
 | .NET | `Resend` | >= 0.2.1 | `dotnet add package Resend` |
 
 > **If the project already has a Resend SDK installed**, check the version and upgrade if it's below the minimum. Older SDKs may be missing `webhooks.verify()`, `emails.receiving.get()`, or `domains.claims.*`, which power webhook security, inbound email, and domain claiming.
@@ -90,7 +90,7 @@ cargo add tokio -F macros,rt-multi-thread
 
 Gradle:
 ```gradle
-implementation 'com.resend:resend-java:4.11.0'
+implementation 'com.resend:resend-java:4.16.0'
 ```
 
 Maven:
@@ -98,7 +98,7 @@ Maven:
 <dependency>
   <groupId>com.resend</groupId>
   <artifactId>resend-java</artifactId>
-  <version>4.11.0</version>
+  <version>4.16.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary
- Update domain claims availability to Node.js, Python, Ruby, Go, Rust, and Java SDKs (plus CLI/REST); PHP and .NET still unsupported
- Add Python claim flow example and per-SDK method naming notes in `domains.md`
- Bump min SDK versions for claims support (Python 2.34.0, Ruby 1.6.0, Go 3.11.0, Rust 0.26.1, Java 4.16.0)
- Update eval #38 expected availability wording

## Test plan
- [ ] Confirm `domains.md` no longer says Node SDK + CLI only
- [ ] Confirm Python example and method naming note are accurate
- [ ] Confirm SKILL.md and installation.md version tables match
- [ ] Validate `evals.json` parses (`python3 -m json.tool`)