### PR TITLE
fix: correct operator enum, allowlist casing, and webhook-secret gating

### DIFF
--- a/skills/agent-email-inbox/SKILL.md
+++ b/skills/agent-email-inbox/SKILL.md
@@ -4,7 +4,7 @@ description: Use when building any system where email content triggers actions â
 license: MIT
 metadata:
     author: resend
-    version: "3.0.2"
+    version: "3.0.3"
     homepage: https://resend.com/agent-skills
     source: https://github.com/resend/resend-skills
     openclaw:
@@ -40,7 +40,7 @@ inputs:
       required: true
     - name: RESEND_WEBHOOK_SECRET
       description: Webhook signing secret for verifying inbound email event payloads. Returned as `signing_secret` in the response when you create a webhook via the API.
-      required: true
+      required: false
 references:
     - security-levels.md
     - webhook-setup.md

--- a/skills/agent-email-inbox/references/security-levels.md
+++ b/skills/agent-email-inbox/references/security-levels.md
@@ -178,7 +178,8 @@ const UNTRUSTED_CAPABILITIES: AgentCapabilities = {
 };
 
 async function processEmailForAgent(eventData: EmailReceivedEvent, emailContent: EmailContent) {
-  const isTrusted = ALLOWED_SENDERS.includes(eventData.from.toLowerCase());
+  const sender = eventData.from.toLowerCase();
+  const isTrusted = ALLOWED_SENDERS.some(allowed => sender === allowed.toLowerCase());
 
   const capabilities = isTrusted ? TRUSTED_CAPABILITIES : UNTRUSTED_CAPABILITIES;
 
@@ -218,7 +219,8 @@ interface PendingAction {
 }
 
 async function processEmailForAgent(eventData: EmailReceivedEvent, emailContent: EmailContent) {
-  const isTrusted = ALLOWED_SENDERS.includes(eventData.from.toLowerCase());
+  const sender = eventData.from.toLowerCase();
+  const isTrusted = ALLOWED_SENDERS.some(allowed => sender === allowed.toLowerCase());
 
   if (isTrusted) {
     await agent.processEmail({ ... });

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -4,7 +4,7 @@ description: Use when working with the Resend email API — sending transactiona
 license: MIT
 metadata:
     author: resend
-    version: "3.5.0"
+    version: "3.5.1"
     homepage: https://resend.com/agent-skills
     source: https://github.com/resend/resend-skills
     openclaw:

--- a/skills/resend/references/automations.md
+++ b/skills/resend/references/automations.md
@@ -149,7 +149,7 @@ const { data, error } = await resend.automations.create({
     {
       key: 'check_plan',
       type: 'condition',
-      config: { type: 'rule', field: 'properties.plan', operator: 'equals', value: 'pro' },
+      config: { type: 'rule', field: 'properties.plan', operator: 'eq', value: 'pro' },
     },
     { key: 'send_pro', type: 'send_email', config: { template: { id: 'tmpl_pro' }, from: 'Acme <hello@acme.com>' } },
     { key: 'send_free', type: 'send_email', config: { template: { id: 'tmpl_free' }, from: 'Acme <hello@acme.com>' } },


### PR DESCRIPTION
Fixes the three defects reported in #98. Found while vendoring these skills into an agent platform; all three were verified against `044372f`.

What makes each one clearly a defect rather than a deliberate choice is that the same file or skill already states the correct thing elsewhere.

### 1. `skills/resend/references/automations.md`

Line 53 documents the supported operators as `eq`, `neq`, `gt`, … but the conditional-branching example used `operator: 'equals'`. Changed to `eq`.

### 2. `skills/agent-email-inbox/references/security-levels.md`

Levels 4 and 5 lower-cased the inbound sender and then compared it against raw allowlist entries:

```ts
const isTrusted = ALLOWED_SENDERS.includes(eventData.from.toLowerCase());
```

A reasonable entry like `Alice@Example.com` therefore never matched, and a trusted sender was silently treated as untrusted.

To be precise about direction: this **fails closed**, so it was never a bypass — no untrusted sender gained trust. The harm is a documented allowlist that quietly does nothing, which is easy to miss because nothing errors.

Both sites now use the comparison this same file already uses at level 1 (line 32):

```ts
const sender = eventData.from.toLowerCase();
const isTrusted = ALLOWED_SENDERS.some(allowed => sender === allowed.toLowerCase());
```

### 3. `skills/agent-email-inbox/SKILL.md`

`RESEND_WEBHOOK_SECRET` was optional under `openclaw.envVars` but required under `inputs`. Beyond the inconsistency, required looks wrong on its own terms: the secret is only returned as `signing_secret` when you create a webhook, and creating that webhook is a step this skill walks the user through — so treating it as a load-time requirement can gate the skill off before the setup that produces it has run. Set to `false` to match `envVars`.

---

Patch versions bumped on both touched skills (`resend` 3.5.0 → 3.5.1, `agent-email-inbox` 3.0.2 → 3.0.3), following the convention in #67 and #15.

Only the two skills AGENTS.md lists as safe to edit here are touched. The webhook-verification bug I also found lives in `email-best-practices`, which syncs in from its own repo — reported separately at resend/email-best-practices#22 with a PR there.