### PR TITLE
docs(broadcasts): document broadcasts.cancel()

### DIFF
--- a/skills/resend/references/broadcasts.md
+++ b/skills/resend/references/broadcasts.md
@@ -10,6 +10,7 @@ Send emails to audience segments. Broadcasts follow a two-step lifecycle: **crea
 | Get | `resend.broadcasts.get(id)` | `resend.Broadcasts.get(id)` |
 | List | `resend.broadcasts.list(params)` | `resend.Broadcasts.list(params)` |
 | Send | `resend.broadcasts.send(id, params?)` | `resend.Broadcasts.send(params)` |
+| Cancel | `resend.broadcasts.cancel(id)` | `resend.Broadcasts.cancel(id)` |
 | Update | `resend.broadcasts.update(id, params)` | `resend.Broadcasts.update(params)` |
 | Delete | `resend.broadcasts.remove(id)` | `resend.Broadcasts.remove(id)` |
 
@@ -66,7 +67,7 @@ const { data, error } = await resend.broadcasts.create({
 });
 ```
 
-## Get, List, Update, Delete
+## Get, List, Update, Cancel, Delete
 
 ```typescript
 // Get
@@ -80,7 +81,12 @@ const { data, error } = await resend.broadcasts.update('bc_abc123', {
   subject: 'Updated subject line',
 });
 
-// Delete a draft (only works on drafts)
+// Cancel a queued or scheduled broadcast — stops a queued send mid-flight, or
+// reverts a scheduled one to draft. Does not remove the broadcast.
+const { data, error } = await resend.broadcasts.cancel('bc_abc123');
+
+// Delete — draft or scheduled only (deleting a scheduled broadcast also
+// cancels its delivery). Sent broadcasts cannot be deleted.
 const { data, error } = await resend.broadcasts.remove('bc_abc123');
 ```
 
@@ -117,7 +123,9 @@ Use triple-mustache with a pipe for fallbacks: `{{{PROPERTY_KEY|fallback}}}`
 |---------|-----|
 | Expecting `create` to send the broadcast | `create` makes a draft. Call `send` separately, or pass `send: true` |
 | Calling `.delete()` instead of `.remove()` | Node.js SDK uses `.remove()` for all delete operations |
-| Deleting a sent/scheduled broadcast | Only drafts can be deleted |
+| Deleting a sent broadcast | Only draft or scheduled broadcasts can be deleted |
+| Cancelling a draft or sent broadcast | Only queued or scheduled broadcasts can be cancelled |
+| Using `.remove()` when you just want to stop delivery | `.cancel()` stops/reverts without deleting the broadcast; `.remove()` deletes it entirely |
 | Missing `segmentId` | Required — broadcasts target segments, not all contacts |
 | Missing unsubscribe link | Include `{{{RESEND_UNSUBSCRIBE_URL}}}` in HTML |
 | `{{VAR}}` instead of `{{{VAR}}}` | Triple braces required for variable interpolation |


### PR DESCRIPTION
## Summary
- Adds `broadcasts.cancel(id)` to the SDK Methods table and the Get/List/Update/Delete example section (renamed to include Cancel).
- Fixes a stale claim that delete "only works on drafts" — scheduled broadcasts can be deleted too (which also cancels their delivery). Adds a Common Mistakes row distinguishing `cancel` (stop/revert, keeps the broadcast) from `remove` (deletes it).

Part of the broadcast cancel rollout: resend/resend-monorepo#8126, resend/resend-openapi#85, resend/resend-node#1059 / #1064, resend/resend-docs#1722, resend/resend-go#144, resend/resend-java#122, resend/resend-php#135, resend/resend-python#250, resend/resend-ruby#216, resend/resend-rust#91, resend/resend-dotnet#136, resend/resend-cli#359, resend/resend-mcp#206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)