### PR TITLE
Fix automation field namespace, domain allowlist casing, and undefined helper

### DIFF
--- a/skills/agent-email-inbox/SKILL.md
+++ b/skills/agent-email-inbox/SKILL.md
@@ -4,7 +4,7 @@ description: Use when building any system where email content triggers actions â
 license: MIT
 metadata:
     author: resend
-    version: "3.0.3"
+    version: "3.0.4"
     homepage: https://resend.com/agent-skills
     source: https://github.com/resend/resend-skills
     openclaw:
@@ -279,6 +279,10 @@ import { Resend } from 'resend';
 
 const app = express();
 const resend = new Resend(process.env.RESEND_API_KEY);
+
+const ALLOWED_SENDERS = (process.env.ALLOWED_SENDERS || '').split(',').filter(Boolean);
+const isAllowedSender = (sender) =>
+  ALLOWED_SENDERS.some(allowed => sender === allowed.toLowerCase());
 
 app.post('/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
   try {

--- a/skills/agent-email-inbox/references/security-levels.md
+++ b/skills/agent-email-inbox/references/security-levels.md
@@ -284,7 +284,7 @@ export async function handleIncomingEmail(event: EmailReceivedWebhookEvent): Pro
 
     case 'domain':
       const domain = sender.split('@')[1];
-      if (!config.allowedDomains.includes(domain)) {
+      if (!config.allowedDomains.some(allowed => domain === allowed.toLowerCase())) {
         await logRejection(event, 'domain_not_allowed');
         return;
       }

--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -4,7 +4,7 @@ description: Use when working with the Resend email API — sending transactiona
 license: MIT
 metadata:
     author: resend
-    version: "3.5.1"
+    version: "3.5.2"
     homepage: https://resend.com/agent-skills
     source: https://github.com/resend/resend-skills
     openclaw:

--- a/skills/resend/references/automations.md
+++ b/skills/resend/references/automations.md
@@ -52,7 +52,7 @@ Groups: `{ "type": "and" | "or", "rules": [...] }` for nesting.
 
 Supported operators: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains`, `starts_with`, `ends_with`, `exists`, `is_empty`. The `exists` and `is_empty` operators require no `value`.
 
-For `condition` steps, fields reference contact data (e.g. `properties.plan`). For `filter_rule` in `wait_for_event`, fields are restricted to `event.*` (e.g. `event.status`).
+For `condition` steps, fields use the `contact.*`, `event.*`, or `wait_events.*` namespaces (e.g. `contact.properties.plan`). For `filter_rule` in `wait_for_event`, fields use `event.*` or `contact.*` (e.g. `event.status`).
 
 ### Connections
 
@@ -149,7 +149,7 @@ const { data, error } = await resend.automations.create({
     {
       key: 'check_plan',
       type: 'condition',
-      config: { type: 'rule', field: 'properties.plan', operator: 'eq', value: 'pro' },
+      config: { type: 'rule', field: 'contact.properties.plan', operator: 'eq', value: 'pro' },
     },
     { key: 'send_pro', type: 'send_email', config: { template: { id: 'tmpl_pro' }, from: 'Acme <hello@acme.com>' } },
     { key: 'send_free', type: 'send_email', config: { template: { id: 'tmpl_free' }, from: 'Acme <hello@acme.com>' } },


### PR DESCRIPTION
Follow-ups from the review of #99.

### 1. `skills/resend/references/automations.md`

The conditional-branching example used `field: 'properties.plan'`. The API validator splits the field on the first `.` and accepts only the `contact`, `event`, and `wait_events` namespaces (`workflow-utils`, enforced with a 422). So the example still produced a failing request after the operator fix in #99. Changed to `contact.properties.plan`, in the example and in the prose.

Also corrected the `filter_rule` claim: `wait_for_event` filters accept `event.*` and `contact.*`, not `event.*` only.

### 2. `skills/agent-email-inbox/references/security-levels.md`

The configurable-security example lowercased the domain and compared it against raw `ALLOWED_DOMAINS` env entries. This is the same defect class #99 fixed for senders, in the same file. Now uses the same case-insensitive pattern.

### 3. `skills/agent-email-inbox/SKILL.md`

The Express example called `isAllowedSender`, which was never defined anywhere in the skill. Defined it from `ALLOWED_SENDERS` with the same comparison the other examples use.

---

Patch bumps on both touched skills: `resend` 3.5.1 → 3.5.2, `agent-email-inbox` 3.0.3 → 3.0.4.