### PR TITLE
feat(resend): document automations.duplicate

### DIFF
--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -4,7 +4,7 @@ description: Use when working with the Resend email API — sending transactiona
 license: MIT
 metadata:
     author: resend
-    version: "3.5.2"
+    version: "3.6.0"
     homepage: https://resend.com/agent-skills
     source: https://github.com/resend/resend-skills
     openclaw:

--- a/skills/resend/references/automations.md
+++ b/skills/resend/references/automations.md
@@ -16,6 +16,7 @@ Automations are created in a `disabled` state by default. Set `status: "enabled"
 | Get | `resend.automations.get(id)` | Returns full automation with steps and connections |
 | List | `resend.automations.list(params?)` | Filter by `status`, cursor-paginated |
 | Update | `resend.automations.update(params)` | Partial update — name, status, or steps+connections |
+| Duplicate | `resend.automations.duplicate(id)` | Copies steps and connections, returns the new automation ID |
 | Delete | `resend.automations.remove(id)` | Permanent |
 | Stop | `resend.automations.stop(id)` | Sets status to `disabled` |
 | List Runs | `resend.automations.runs.list({ automationId, status? })` | Filter by run status |
@@ -23,7 +24,7 @@ Automations are created in a `disabled` state by default. Set `status: "enabled"
 
 ### Python
 
-`resend.Automations.create/get/list/update/remove/stop` — same operations with snake_case params.
+`resend.Automations.create/get/list/update/remove/duplicate/stop` — same operations with snake_case params.
 
 ## Graph Model
 
@@ -205,6 +206,14 @@ const { data: run } = await resend.automations.runs.get({
 ```typescript
 const { data, error } = await resend.automations.stop('aut_abc123');
 // data.status === 'disabled'
+```
+
+### Duplicate an Automation
+
+```typescript
+const { data, error } = await resend.automations.duplicate('aut_abc123');
+// data.id is the new automation's ID
+// The copy starts disabled, named "<original name> (Copy)"
 ```
 
 ## Constraints


### PR DESCRIPTION
The `POST /automations/:id/duplicate` endpoint shipped in every SDK, but the `resend` skill's automations reference still ended its method table at `stop`.

Adds:

- a `Duplicate` row to the Node.js method table
- `duplicate` to the Python method list
- a short example after "Stop an Automation"
- skill version 3.5.2 → 3.6.0 (minor for a new capability, matching #97's precedent)

The example's behavioral claims are verified against the public-api implementation, not guessed: the insert sets only `name: `${source.name} (Copy)`` and the `status` column defaults to `disabled`, so the copy starts disabled and is named "<original> (Copy)".

Only `skills/resend` is touched — authored here per the README. The `resend-cli` skill gets its own duplicate coverage via the automatic sync once resend/resend-cli#364 merges.

Tracked by DEV-1703. Same endpoint elsewhere: resend/resend-docs#1757, resend/resend-cli#364, resend/resend-mcp#209, resend/resend-monorepo#8815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)