### PR TITLE
fix(resend): use the id key in the Python api-keys update sample

### DIFF
--- a/skills/resend/references/api-keys.md
+++ b/skills/resend/references/api-keys.md
@@ -85,7 +85,7 @@ keys = resend.ApiKeys.list()
 
 # Rename a key (only "name" is patchable)
 resend.ApiKeys.update({
-    "api_key_id": "api_key_id",
+    "id": "api_key_id",
     "name": "Production Sending Key v2",
 })
 


### PR DESCRIPTION
resend-python 2.40.2 renames the `ApiKeys.update` params key from `api_key_id` to `id` (resend/resend-python#269). #112 documented the method with the old key.

Same fix in flight: resend/resend-docs#1779 (docs Python tab) and resend/resend-monorepo#9115 (dashboard drawer). All should land once PyPI serves 2.40.2. The `remove(api_key_id=...)` samples are correct and unchanged.