### PR TITLE
fix(resend): make the attachments and topics reference samples match the SDKs

### DIFF
--- a/skills/resend/references/receiving.md
+++ b/skills/resend/references/receiving.md
@@ -254,7 +254,7 @@ export async function POST(req: Request) {
       to: ['team@acme.com'],
       subject: `Fwd: ${email.subject}`,
       html: email.html ?? undefined,
-      text: email.text ?? undefined,
+      text: email.text ?? '',
       attachments,
     });
 

--- a/skills/resend/references/receiving.md
+++ b/skills/resend/references/receiving.md
@@ -213,19 +213,33 @@ export async function POST(req: Request) {
 
   if (event.type === 'email.received') {
     // 1. Get email content
-    const { data: email } = await resend.emails.receiving.get(
+    const { data: email, error: emailError } = await resend.emails.receiving.get(
       event.data.email_id
     );
 
+    if (emailError) {
+      console.error(emailError);
+      return new Response('Failed to fetch email', { status: 500 });
+    }
+
     // 2. Get attachments (if any)
-    const { data: attachmentList } = await resend.emails.receiving.attachments.list({
-      emailId: event.data.email_id,
-    });
+    const { data: attachmentList, error: attachmentsError } =
+      await resend.emails.receiving.attachments.list({
+        emailId: event.data.email_id,
+      });
+
+    if (attachmentsError) {
+      console.error(attachmentsError);
+      return new Response('Failed to list attachments', { status: 500 });
+    }
 
     // 3. Download and encode attachments
     const attachments = await Promise.all(
       attachmentList.data.map(async (att) => {
         const res = await fetch(att.download_url);
+        if (!res.ok) {
+          throw new Error(`Failed to download ${att.filename}`);
+        }
         const buffer = Buffer.from(await res.arrayBuffer());
         return {
           filename: att.filename,
@@ -235,14 +249,19 @@ export async function POST(req: Request) {
     );
 
     // 4. Forward the email (single send — batch doesn't support attachments)
-    await resend.emails.send({
+    const { error: sendError } = await resend.emails.send({
       from: 'Support System <system@acme.com>',
       to: ['team@acme.com'],
       subject: `Fwd: ${email.subject}`,
-      html: email.html,
-      text: email.text,
+      html: email.html ?? undefined,
+      text: email.text ?? undefined,
       attachments,
     });
+
+    if (sendError) {
+      console.error(sendError);
+      return new Response('Failed to forward email', { status: 500 });
+    }
   }
 
   return new Response('OK', { status: 200 });

--- a/skills/resend/references/receiving.md
+++ b/skills/resend/references/receiving.md
@@ -167,7 +167,7 @@ const { data: attachments } = await resend.emails.receiving.attachments.list({
   emailId: event.data.email_id,
 });
 
-for (const attachment of attachments) {
+for (const attachment of attachments.data) {
   console.log(attachment.filename);
   console.log(attachment.download_url);  // signed URL, see expires_at
   console.log(attachment.expires_at);
@@ -179,7 +179,7 @@ for (const attachment of attachments) {
 ```typescript
 const { data: attachment } = await resend.emails.receiving.attachments.get({
   emailId: event.data.email_id,
-  attachmentId: 'att_abc123',
+  id: 'att_abc123',
 });
 
 console.log(attachment.download_url); // signed URL
@@ -224,7 +224,7 @@ export async function POST(req: Request) {
 
     // 3. Download and encode attachments
     const attachments = await Promise.all(
-      attachmentList.map(async (att) => {
+      attachmentList.data.map(async (att) => {
         const res = await fetch(att.download_url);
         const buffer = Buffer.from(await res.arrayBuffer());
         return {

--- a/skills/resend/references/sending/email-management.md
+++ b/skills/resend/references/sending/email-management.md
@@ -109,9 +109,14 @@ List and download attachments for sent emails. Returns metadata and a signed dow
 
 ```typescript
 // List all attachments for a sent email
-const { data: attachments } = await resend.emails.attachments.list({
+const { data: attachments, error } = await resend.emails.attachments.list({
   emailId: 'email_abc123',
 });
+
+if (error) {
+  console.error(error);
+  return;
+}
 
 for (const att of attachments.data) {
   console.log(att.filename);      // 'invoice.pdf'
@@ -121,10 +126,15 @@ for (const att of attachments.data) {
 }
 
 // Get a single attachment
-const { data: attachment } = await resend.emails.attachments.get({
+const { data: attachment, error: getError } = await resend.emails.attachments.get({
   emailId: 'email_abc123',
   id: 'att_def456',
 });
+
+if (getError) {
+  console.error(getError);
+  return;
+}
 
 // Download the content
 const response = await fetch(attachment.download_url);

--- a/skills/resend/references/sending/email-management.md
+++ b/skills/resend/references/sending/email-management.md
@@ -103,7 +103,7 @@ List and download attachments for sent emails. Returns metadata and a signed dow
 | Operation | Node.js | Python |
 |-----------|---------|--------|
 | List | `resend.emails.attachments.list({ emailId })` | `resend.Emails.Attachments.list(email_id)` |
-| Get | `resend.emails.attachments.get({ emailId, attachmentId })` | `resend.Emails.Attachments.get(email_id, attachment_id)` |
+| Get | `resend.emails.attachments.get({ emailId, id })` | `resend.Emails.Attachments.get(email_id, attachment_id)` |
 
 ### Examples
 
@@ -123,7 +123,7 @@ for (const att of attachments.data) {
 // Get a single attachment
 const { data: attachment } = await resend.emails.attachments.get({
   emailId: 'email_abc123',
-  attachmentId: 'att_def456',
+  id: 'att_def456',
 });
 
 // Download the content

--- a/skills/resend/references/topics.md
+++ b/skills/resend/references/topics.md
@@ -20,7 +20,7 @@ Fine-grained subscription preferences — contacts opt in or out per topic. Topi
 |-----------|--------|
 | Create | `resend.Topics.create(params)` |
 | Get | `resend.Topics.get(id)` |
-| List | `resend.Topics.list()` |
+| List | `resend.Topics.list(params?)` — `limit`, `after`, `before` |
 | Update | `resend.Topics.update(id, params)` |
 | Delete | `resend.Topics.remove(id)` |
 
@@ -43,7 +43,7 @@ console.log(data.id); // topic_xxxxxxxx
 
 ## Update Topic
 
-`defaultSubscription` is **immutable** after creation. Only `name` and `description` can be updated through the SDK. The API also accepts `visibility`.
+`defaultSubscription` is **immutable** after creation. Only `name`, `description`, and `visibility` can be updated.
 
 ```typescript
 const { data, error } = await resend.topics.update({
@@ -51,6 +51,11 @@ const { data, error } = await resend.topics.update({
   name: 'Product News',
   description: 'News about our products',
 });
+
+if (error) {
+  console.error(error);
+  return;
+}
 ```
 
 ## Managing Contact Subscriptions
@@ -89,7 +94,7 @@ await resend.broadcasts.create({
 | Name max length | 50 characters |
 | Description max length | 200 characters |
 | `defaultSubscription` | `"opt_in"` or `"opt_out"` — immutable after create |
-| `visibility` | `"public"` (shown on preference page) or `"private"` (default). API only, not in the Node or Python SDK types yet |
+| `visibility` | `"public"` (shown on the unsubscribe page) or `"private"` (default) |
 
 ## Common Mistakes
 
@@ -99,6 +104,4 @@ await resend.broadcasts.create({
 | Trying to change `defaultSubscription` | Immutable after creation — delete and recreate with new value |
 | Calling `.delete()` | SDK method is `.remove()` |
 | `visibility: "hidden"` | Not a valid value — use `"private"` |
-| Passing `visibility` to the Node or Python SDK | Not in the SDK types yet. Set it with the REST API or in the dashboard |
-| Expecting `list()` to accept pagination | `topics.list()` takes no params — returns all topics |
 | Broadcast without `topicId` | Goes to all contacts in segment regardless of topic preferences |

--- a/skills/resend/references/topics.md
+++ b/skills/resend/references/topics.md
@@ -21,7 +21,7 @@ Fine-grained subscription preferences — contacts opt in or out per topic. Topi
 | Create | `resend.Topics.create(params)` |
 | Get | `resend.Topics.get(id)` |
 | List | `resend.Topics.list()` |
-| Update | `resend.Topics.update(params)` |
+| Update | `resend.Topics.update(id, params)` |
 | Delete | `resend.Topics.remove(id)` |
 
 ## Create Topic
@@ -31,7 +31,6 @@ const { data, error } = await resend.topics.create({
   name: 'Product Updates',
   defaultSubscription: 'opt_in',  // REQUIRED: "opt_in" or "opt_out"
   description: 'New features and releases',
-  visibility: 'public',  // "public" or "private" (default: "private")
 });
 
 if (error) {
@@ -44,13 +43,13 @@ console.log(data.id); // topic_xxxxxxxx
 
 ## Update Topic
 
-`defaultSubscription` is **immutable** after creation. Only `name`, `description`, and `visibility` can be updated.
+`defaultSubscription` is **immutable** after creation. Only `name` and `description` can be updated through the SDK. The API also accepts `visibility`.
 
 ```typescript
 const { data, error } = await resend.topics.update({
   id: 'topic_xxx',
   name: 'Product News',
-  visibility: 'public',
+  description: 'News about our products',
 });
 ```
 
@@ -90,7 +89,7 @@ await resend.broadcasts.create({
 | Name max length | 50 characters |
 | Description max length | 200 characters |
 | `defaultSubscription` | `"opt_in"` or `"opt_out"` — immutable after create |
-| `visibility` | `"public"` (shown on preference page) or `"private"` (default) |
+| `visibility` | `"public"` (shown on preference page) or `"private"` (default). API only, not in the Node or Python SDK types yet |
 
 ## Common Mistakes
 
@@ -100,5 +99,6 @@ await resend.broadcasts.create({
 | Trying to change `defaultSubscription` | Immutable after creation — delete and recreate with new value |
 | Calling `.delete()` | SDK method is `.remove()` |
 | `visibility: "hidden"` | Not a valid value — use `"private"` |
+| Passing `visibility` to the Node or Python SDK | Not in the SDK types yet. Set it with the REST API or in the dashboard |
 | Expecting `list()` to accept pagination | `topics.list()` takes no params — returns all topics |
 | Broadcast without `topicId` | Goes to all contacts in segment regardless of topic preferences |


### PR DESCRIPTION
Agents that follow the Resend skill now get attachment and topic samples that work with the current Node and Python SDKs.

Before, three reference pages showed code the SDKs reject. The receiving reference looped over the attachment list as if it were an array, and asked for a single attachment with an option name the SDK does not have. The topics reference set the topic visibility in samples that no released SDK accepts, and listed the Python update method with the wrong shape. An agent that copied any of these produced code that failed to type check, and the developer had to debug generated code against the SDK types.

Now every sample in those pages matches the SDK it targets. The topics reference still documents visibility as an API field, and says plainly that the SDKs do not expose it yet.

How to reach it. Install the `resend` skill and ask an agent to download the attachments of a received email, or to update a topic. The generated code compiles as is.

Not covered. Visibility stays unavailable through the Node and Python SDKs until they add the field.

DEV-2065
