### PR TITLE
feat(broadcasts): document the duplicate endpoint

### DIFF
--- a/skills/resend/SKILL.md
+++ b/skills/resend/SKILL.md
@@ -4,7 +4,7 @@ description: Use when working with the Resend email API — sending transactiona
 license: MIT
 metadata:
     author: resend
-    version: "3.9.0"
+    version: "3.10.0"
     homepage: https://resend.com/agent-skills
     source: https://github.com/resend/resend-skills
     openclaw:

--- a/skills/resend/references/broadcasts.md
+++ b/skills/resend/references/broadcasts.md
@@ -11,6 +11,7 @@ Send emails to audience segments. Broadcasts follow a two-step lifecycle: **crea
 | List | `resend.broadcasts.list(params)` | `resend.Broadcasts.list(params)` |
 | Send | `resend.broadcasts.send(id, params?)` | `resend.Broadcasts.send(params)` |
 | Cancel | `resend.broadcasts.cancel(id)` | `resend.Broadcasts.cancel(id)` |
+| Duplicate | `resend.broadcasts.duplicate(id)` | `resend.Broadcasts.duplicate(id)` |
 | Update | `resend.broadcasts.update(id, params)` | `resend.Broadcasts.update(params)` |
 | Delete | `resend.broadcasts.remove(id)` | `resend.Broadcasts.remove(id)` |
 | Clicked Links | `resend.broadcasts.clickedLinks(id, params?)` | `resend.Broadcasts.clicked_links(id, params?)` |
@@ -69,7 +70,7 @@ const { data, error } = await resend.broadcasts.create({
 });
 ```
 
-## Get, List, Update, Cancel, Delete
+## Get, List, Update, Cancel, Duplicate, Delete
 
 ```typescript
 // Get
@@ -86,6 +87,10 @@ const { data, error } = await resend.broadcasts.update('bc_abc123', {
 // Cancel a queued or scheduled broadcast — stops a queued send mid-flight, or
 // reverts a scheduled one to draft. Does not remove the broadcast.
 const { data, error } = await resend.broadcasts.cancel('bc_abc123');
+
+// Duplicate — creates a new draft named "<name> (copy)" with the same content.
+// Works on any broadcast, including sent ones. Returns the new broadcast's id.
+const { data, error } = await resend.broadcasts.duplicate('bc_abc123');
 
 // Delete — draft or scheduled only (deleting a scheduled broadcast also
 // cancels its delivery). Sent broadcasts cannot be deleted.


### PR DESCRIPTION
This documents `POST /broadcasts/{id}/duplicate` in the `resend` skill: a row in the broadcasts SDK table and a call in the TypeScript block, same shape as `templates.duplicate`. The lines assume `resend.broadcasts.duplicate(id)` from resend@6.28.0 and `resend.Broadcasts.duplicate(id)` from resend python 2.45.0, so this merges once both are released. Spec: https://github.com/resend/resend-openapi/pull/115

The snippet was not run: it targets resend@6.28.0, which is still in flight in resend/resend-node and not on npm yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)